### PR TITLE
WXT536 Script Update 

### DIFF
--- a/wxt-536/run_wxt.py
+++ b/wxt-536/run_wxt.py
@@ -1,15 +1,28 @@
 import serial
 import time
+import argparse
+import csv
 
 from datetime import datetime
 
 # To display current ports:
 # python -m serial.tools.list_ports
 
-def pollsave():
-    # Initalize communication with the instrument
-    #ser.write(b'0R0\r\n')
-    ser.write(b'0R\r\n')
+def search_ports(args):
+    """
+    Serial to USB devices can mount randomly to ports during reboot of a system.
+
+    This function searches all available ports and determines the specific port
+    for the WXT-536
+    """
+    # define all available ports
+    
+
+def pollsave(args):
+    # check if you need to poll the data
+    if args.poll is True:
+        # Initalize communication with the instrument
+        ser.write(bytearray(args.query + '\r\n', 'utf-8'))
     # Read the incoming serial data
     data = ser.readline()
     # check to make sure data are being returned
@@ -21,27 +34,88 @@ def pollsave():
         datetime = None
 
     return datatime
- 
-if __name__ == '__main__':
+
+def main(args):
     # start serial connection:
-    with serial.Serial('/dev/ttyUSB3', 19200, timeout = 1) as ser:
-        starttime = time.time()
+    with serial.Serial(args.device, args.baud_rate, timeout = 1) as ser:
         # create a file to write data to
-        filename = 'WXT530_' + datetime.now().strftime("%Y%m%d.%H%M%S") + '.txt'
+        nfile = 'WXT536_' + args.site + '_' + datetime.now().strftime("%Y%m%d.%H%M%S")
+        # check desired output from user. supports netcdf or csv
+        if args.output == 'nc' or args.output == 'netcdf':
+            filename = nfile + '.nc'
+        else:
+            filename = nfile + '.csv'
+        # While Serial connection is valid
         while True:
             try:
-                # poll the data
-                ndata = pollsave()
-                # Append to the file. 
-                with open(filename, "a") as myfile:
-                    try:
-                        if ndata is not None:
-                            myfile.write(ndata)
-                            print(ndata)
-                    except:
-                        print('Unable to write to file')                     
-                time.sleep(1.00)
+                # query the instrument
+                ndata = pollsave(args)
+                # check to see if anything is returned
+                ### Add debug line here? -> check how to store values
+                if ndata:
+                    if args.output == 'nc' or args.output == 'netcdf':
+                        print("netcdf stuff")
+                    else:
+                        # Append to the file. 
+                        with open(filename, "a") as myfile:
+                            try:
+                                writer = csv.writer(myfile, delimiter=",")
+                                writer.writerow(ndata)
+                            except:
+                                print('Unable to write to file')                     
+                time.sleep(args.freq)
             except:
                 print("Keyboard Interrupt")
-                break
+ 
+if __name__ == '__main__':
+     parser = argparse.ArgumentParser(
+            description="Script for interfacing with Viasala WXT 2D anemometer data")
+ 
+     parser.add_argument("--debug",
+                         action="store_true",
+                         dest='debug',
+                         help="enable debug logs"
+                         )
+     parser.add_argument("--device",
+                         type=str,
+                         dest='device',
+                         default="/dev/ttyUSB0",
+                         help="serial device to use"
+                         )
+     parser.add_argument("--baudrate",
+                         type=int,
+                         dest='baud_rate',
+                         default=19200,
+                         help="baudrate to use"
+                         )
+     parser.add_argument("--poll",
+                         type=bool,
+                         default=False,
+                         help="Boolean Flag for if data are polled"
+                         )
+     parser.add_argument("--query",
+                         type=str,
+                         default="0R",
+                         help="ASCII query command to send to the instrument"
+                        )
+     parser.add_argument("--output",
+                         type=str,
+                         dest='output',
+                         default="csv",
+                         help="output file format (csv or nc)"
+                         )
+     parser.add_argument("--site",
+                         type=str,
+                         dest="site",
+                         default="atmos",
+                         help="Site Identifier for Filename"
+                         )
+     parser.add_argument("--frequency",
+                         type=int,
+                         default=1,
+                         dest="freq",
+                         help="Temporal frequency of the data aquesition"
+                         )
+     args = parser.parse_args()
 
+     main(args)

--- a/wxt-536/run_wxt.py
+++ b/wxt-536/run_wxt.py
@@ -8,16 +8,8 @@ from datetime import datetime
 # To display current ports:
 # python -m serial.tools.list_ports
 
-def search_ports(args):
-    """
-    Serial to USB devices can mount randomly to ports during reboot of a system.
-
-    This function searches all available ports and determines the specific port
-    for the WXT-536
-    """
-    # define all available ports
+## needs a search ports functionality
     
-
 def pollsave(args):
     # check if you need to poll the data
     if args.poll is True:
@@ -119,3 +111,4 @@ if __name__ == '__main__':
      args = parser.parse_args()
 
      main(args)
+

--- a/wxt-536/run_wxt.py
+++ b/wxt-536/run_wxt.py
@@ -10,13 +10,16 @@ from datetime import datetime
 
 ## needs a search ports functionality
     
-def pollsave(args):
+def pollsave(ser, args):
     # check if you need to poll the data
     if args.poll is True:
         # Initalize communication with the instrument
         ser.write(bytearray(args.query + '\r\n', 'utf-8'))
     # Read the incoming serial data
     data = ser.readline()
+    # if verbose is set, print output
+    if args.verbose:
+        print(data)
     # check to make sure data are being returned
     if data:
         # define a timestamp for the data and append to data string
@@ -41,7 +44,7 @@ def main(args):
         while True:
             try:
                 # query the instrument
-                ndata = pollsave(args)
+                ndata = pollsave(ser, args)
                 # check to see if anything is returned
                 ### Add debug line here? -> check how to store values
                 if ndata:
@@ -63,22 +66,22 @@ if __name__ == '__main__':
      parser = argparse.ArgumentParser(
             description="Script for interfacing with Viasala WXT 2D anemometer data")
  
-     parser.add_argument("--debug",
+     parser.add_argument("--verbose",
                          action="store_true",
-                         dest='debug',
-                         help="enable debug logs"
+                         dest='verbose',
+                         help="Enable Output of Serial Communication to Screen"
                          )
      parser.add_argument("--device",
                          type=str,
                          dest='device',
                          default="/dev/ttyUSB0",
-                         help="serial device to use"
+                         help="Specific Serial Port for Device Communication"
                          )
      parser.add_argument("--baudrate",
                          type=int,
                          dest='baud_rate',
                          default=19200,
-                         help="baudrate to use"
+                         help="Baud Rate for Serial Device Communication"
                          )
      parser.add_argument("--poll",
                          type=bool,
@@ -90,7 +93,7 @@ if __name__ == '__main__':
                          default="0R",
                          help="ASCII query command to send to the instrument"
                         )
-     parser.add_argument("--output",
+     parser.add_argument("--format",
                          type=str,
                          dest='output',
                          default="csv",

--- a/wxt-536/run_wxt.py
+++ b/wxt-536/run_wxt.py
@@ -26,7 +26,7 @@ def pollsave(ser, args):
         time = datetime.now().strftime("%Y%m%dT%H:%M:%S.%f")
         datatime = time + ','+ data.decode('utf-8')
     else:
-        datetime = None
+        datatime = None
 
     return datatime
 
@@ -42,25 +42,22 @@ def main(args):
             filename = nfile + '.csv'
         # While Serial connection is valid
         while True:
-            try:
-                # query the instrument
-                ndata = pollsave(ser, args)
-                # check to see if anything is returned
-                ### Add debug line here? -> check how to store values
-                if ndata:
-                    if args.output == 'nc' or args.output == 'netcdf':
-                        print("netcdf stuff")
-                    else:
-                        # Append to the file. 
-                        with open(filename, "a") as myfile:
-                            try:
-                                writer = csv.writer(myfile, delimiter=",")
-                                writer.writerow(ndata)
-                            except:
-                                print('Unable to write to file')                     
-                time.sleep(args.freq)
-            except:
-                print("Keyboard Interrupt")
+            # query the instrument
+            ndata = pollsave(ser, args)
+            # check to see if anything is returned
+            ### Add debug line here? -> check how to store values
+            if ndata:
+                if args.output == 'nc' or args.output == 'netcdf':
+                    print("Needs support... switch to csv")
+                else:
+                    # Append to the file. 
+                    with open(filename, "a") as myfile:
+                        try:
+                            writer = csv.writer(myfile, delimiter=",")
+                            writer.writerow(ndata.strip().split(','))
+                        except:
+                            print('Unable to write to file: ', filename)
+            time.sleep(args.freq)
  
 if __name__ == '__main__':
      parser = argparse.ArgumentParser(


### PR DESCRIPTION
Update of `run_wxt.py` script to allow for command line arguments to change serial ports, baud rate, and instrument query command from the command line. 

Additionally, added verbose option to get raw output from instrument and a check if instrument is configured for polled or automatic data output. 

Currently only supports csv file output, but development is underway for netcdf